### PR TITLE
Point api to port 3000

### DIFF
--- a/nuxtent.config.js
+++ b/nuxtent.config.js
@@ -8,5 +8,11 @@ module.exports = {
         'get',
         'getAll'
     ]
+  },
+  api: {
+    baseURL:
+      process.env.NODE_ENV === 'production'
+        ? 'https://nuxtent.now.sh'
+        : 'http://localhost:3000'
   }
 }


### PR DESCRIPTION
This works around the wrong port and manages to generate, but content isn't accessible.
Perhaps it's not desirable to set this manually, but rather fix it in `nuxtent-module`. Still I thought I'd share as I almost ran out of time for tonight.